### PR TITLE
Create signed windows builds 

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -20,5 +20,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install AzureSignTool
+        run: dotnet tool install --global AzureSignTool
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.TOOLS__AZURE_CREDENTIALS }}
+
+      - name: Set Azure token on environment
+        run: |
+          $az_token=$(az account get-access-token --scope https://vault.azure.net/.default --query accessToken --output tsv)
+          echo "::add-mask::$az_token"
+          echo "AZURE_KEY_VAULT_ACCESS_TOKEN=$az_token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Build Electron app
         run: npm run build:win
+        env:
+          AZURE_KEY_VAULT_TIMESTAMP_URL: ${{ secrets.AZURE_KEY_VAULT_TIMESTAMP_URL }}
+          AZURE_KEY_VAULT_CERTIFICATE_NAME: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
+          AZURE_KEY_VAULT_URL: ${{ secrets.AZURE_KEY_VAULT_URL }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -1,0 +1,24 @@
+name: Continuous Deployment
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Electron app
+        run: npm run build:win

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -39,3 +39,9 @@ jobs:
           AZURE_KEY_VAULT_TIMESTAMP_URL: ${{ secrets.AZURE_KEY_VAULT_TIMESTAMP_URL }}
           AZURE_KEY_VAULT_CERTIFICATE_NAME: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
           AZURE_KEY_VAULT_URL: ${{ secrets.AZURE_KEY_VAULT_URL }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: |
+            **/dist/*.exe
+            **/dist/win-unpacked/*.exe

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,6 +13,7 @@ asarUnpack:
   - resources/**
 win:
   executableName: library
+  sign: ./scripts/sign.js
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/scripts/sign.js
+++ b/scripts/sign.js
@@ -1,0 +1,34 @@
+const {
+  AZURE_KEY_VAULT_TIMESTAMP_URL,
+  AZURE_KEY_VAULT_ACCESS_TOKEN,
+  AZURE_KEY_VAULT_URL,
+  AZURE_KEY_VAULT_CERTIFICATE_NAME,
+} = process.env
+
+Object.entries({
+  AZURE_KEY_VAULT_TIMESTAMP_URL,
+  AZURE_KEY_VAULT_ACCESS_TOKEN,
+  AZURE_KEY_VAULT_URL,
+  AZURE_KEY_VAULT_CERTIFICATE_NAME,
+}).forEach(([key, value]) => {
+  if (!value) throw new Error(`Missing environment variable ${key}`)
+})
+
+const { execSync } = require('child_process')
+
+const sign = async ({ path }) => {
+  execSync(
+    [
+      'AzureSignTool',
+      'sign',
+      `-kva ${AZURE_KEY_VAULT_ACCESS_TOKEN}`,
+      `-kvu ${AZURE_KEY_VAULT_URL}`,
+      `-kvc ${AZURE_KEY_VAULT_CERTIFICATE_NAME}`,
+      `-tr ${AZURE_KEY_VAULT_TIMESTAMP_URL}`,
+      path,
+    ].join(' '),
+    { stdio: 'inherit' }
+  )
+}
+
+exports.default = sign


### PR DESCRIPTION
Adds GH workflows to build the windows installer on push to `main`. Uses our new EV certificate to sign the builds 😎 